### PR TITLE
Set up multi-course site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# who4u78.github.io
+# Course Material Hub
+
+This repository hosts the website for multiple courses using GitHub Pages and Jekyll.
+
+* **Course A** - introductory material
+* **Course B** - advanced material
+
+Visit [https://who4u78.github.io](https://who4u78.github.io) to view the site.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,16 @@
+remote_theme: "mmistakes/minimal-mistakes@4.24.0"
+plugins:
+  - jekyll-feed
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+title: "Course Material Hub"
+author: "Who4u78"
+
+# defaults
+defaults:
+  - scope:
+      path: ""
+      type: "pages"
+    values:
+      layout: "single"

--- a/course-a/index.md
+++ b/course-a/index.md
@@ -1,0 +1,6 @@
+---
+layout: single
+title: "Course A"
+---
+
+Welcome to Course A. Course materials will appear here.

--- a/course-b/index.md
+++ b/course-b/index.md
@@ -1,0 +1,6 @@
+---
+layout: single
+title: "Course B"
+---
+
+Welcome to Course B. Course materials will appear here.

--- a/index.md
+++ b/index.md
@@ -1,5 +1,10 @@
 ---
 layout: home
+title: "Course Material Hub"
 author_profile: true
 ---
 
+Welcome to the course material hub. Select a course below:
+
+- [Course A](/course-a/)
+- [Course B](/course-b/)


### PR DESCRIPTION
## Summary
- add Jekyll config with Minimal Mistakes theme
- update README with course information
- list courses on the home page
- add placeholders for Course A and Course B

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687087837e788331aab94cbecf487002